### PR TITLE
feat(admin/product-type-form): add dependent selects for category, subcategory and type

### DIFF
--- a/src/api/productTypes.js
+++ b/src/api/productTypes.js
@@ -12,8 +12,8 @@ export const getProductTypes = async (params) => {
 
 export const createProductType = async (body) => {
   try {
-    const { data } = await privateApi.post("/product-types", body);
-    return data;
+    const resp = await privateApi.post("/product-types", body);
+    return resp;
   } catch (error) {
     console.error("Error creating product type:", error);
     throw new Error(error.response.data.message);
@@ -22,8 +22,8 @@ export const createProductType = async (body) => {
 
 export const updateProductType = async (id, body) => {
   try {
-    const { data } = await privateApi.put(`/product-types/${id}`, body);
-    return data;
+    const resp = await privateApi.put(`/product-types/${id}`, body);
+    return resp;
   } catch (error) {
     console.error("Error updating product type:", error);
     throw new Error(error.response.data.message);

--- a/src/app/(admin)/admin/add-product/AddProduct.js
+++ b/src/app/(admin)/admin/add-product/AddProduct.js
@@ -81,6 +81,9 @@ const AddProduct = () => {
   });
 
   const brandId = watch("brandId");
+  const categoryId = watch("categoryId");
+  const subCategoryId = watch("subCategoryId");
+  const hasType = watch("hasType");
 
   const { enqueueSnackbar } = useSnackbar();
 
@@ -110,26 +113,54 @@ const AddProduct = () => {
   }, [brandId]);
 
   useEffect(() => {
+    if (!categoryId) return;
+
+    const fetchSubcategories = async () => {
+      try {
+        const res = await getSubcategories({ categoryId });
+        setSubcategories(res.subcategories);
+        setValue("subCategoryId", "");
+        setValue("typeId", "");
+        setTypes([]);
+      } catch (err) {
+        console.error("Error fetching subcategories:", err);
+      }
+    };
+
+    fetchSubcategories();
+  }, [categoryId]);
+
+  useEffect(() => {
+    if (!subCategoryId || subCategoryId === "") return;
+
+    const fetchTypes = async () => {
+      try {
+        const res = await getProductTypes({ subcategoryId: subCategoryId });
+        setTypes(res.productTypes || res.data.productTypes || []);
+        setValue("typeId", "");
+      } catch (err) {
+        console.error("Error fetching product types:", err);
+      }
+    };
+
+    fetchTypes();
+  }, [subCategoryId]);
+
+  useEffect(() => {
     const fetchInitialData = async () => {
       try {
         const [
           brandsData,
           categoriesData,
-          subcategoriesData,
-          typesData,
           measuresData,
         ] = await Promise.all([
           getBrands(),
           getCategories(),
-          getSubcategories(),
-          getProductTypes(),
           getMeasures(),
           getProductModels(),
         ]);
         setBrands(brandsData.brands);
         setCategories(categoriesData.categories);
-        setSubcategories(subcategoriesData.subcategories);
-        setTypes(typesData.productTypes);
         setMeasures(measuresData);
       } catch (error) {
         console.error("Error fetching initial data:", error);
@@ -274,8 +305,6 @@ const AddProduct = () => {
   const handleRowModesModelChange = (newRowModesModel) => {
     setRowModesModel(newRowModesModel);
   };
-
-  const hasType = watch("hasType");
 
   return (
     <Grid

--- a/src/app/(admin)/admin/product-type/columns.js
+++ b/src/app/(admin)/admin/product-type/columns.js
@@ -1,3 +1,9 @@
 export const productTypesColumns = [
   { field: "name", headerName: "Nombre", flex: 1 },
+  {
+    field: "subcategory",
+    headerName: "Subcategoría Asociada",
+    renderCell: (params) => params.row.subCategory?.name || "Sin subcategoría",
+    flex: 1,
+  },
 ];

--- a/src/app/(admin)/admin/subcategories/Subcategories.jsx
+++ b/src/app/(admin)/admin/subcategories/Subcategories.jsx
@@ -39,6 +39,7 @@ const Subcategories = () => {
       console.error("Error fetching initial data:", error);
     }
   };
+
   useEffect(() => {
     fetchInitialData();
   }, [paginationModel]);
@@ -66,6 +67,7 @@ const Subcategories = () => {
       };
 
       const response = await createSubcategory(body);
+      
       if (response.status === 201) {
         const { subcategory } = response.data;
         const newSubcategory = {

--- a/src/components/ActionModal.jsx
+++ b/src/components/ActionModal.jsx
@@ -53,7 +53,18 @@ const ActionModal = ({
   useEffect(() => {
     if (mode === "edit" && selected) {
       setValue("name", selected.name);
-      setValue(option, selected.category?.id || "");
+
+      const getRelationKey = (option) => {
+        const map = {
+          categoryId: "category",
+          subcategoryId: "subCategory",
+        };
+        return map[option] || null;
+      };
+
+      const relationKey = getRelationKey(option);
+      const relatedObject = selected[relationKey];
+      setValue(option, relatedObject?.id || "");
     }
   }, [mode, selected, setValue]);
 

--- a/src/components/CrudAdminTable.jsx
+++ b/src/components/CrudAdminTable.jsx
@@ -59,7 +59,7 @@ const CrudAdminTable = ({
       field: "actions",
       type: "actions",
       headerName: "Acciones",
-      flex: 0.2,
+      flex: 0.3,
       getActions: ({ row }) => {
         return [
           <GridActionsCellItem


### PR DESCRIPTION
## **Summary**  
This MR adds **dependent select dropdowns** to the Product Type form in the Admin panel. The dropdowns for **Subcategory** and **Product Type** dynamically update based on the selected **Category**, enabling a more intuitive and accurate product classification workflow.

## **Changes Included**

### 🚀 Features  
- **Product Type Form Enhancements**:  
  - Implemented cascading dropdowns for Category → Subcategory → Product Type.  
  - Updated internal state handling to dynamically fetch options based on user selections.  
  - Improved form validation to ensure proper combinations are selected.

## **How to Test**

1. Navigate to the Admin section → Product Types.
2. In the form:
   - Select a **Category** and confirm that the **Subcategory** dropdown updates correctly.
   - Select a **Subcategory** and confirm that the **Product Type** dropdown is filtered accordingly.
   - Submit the form and verify that selected values are persisted properly.

3. Inspect network/API requests to validate that:
   - Subcategories and product types are fetched dynamically.
   - Invalid or unrelated combinations are not permitted.

## **Related Issues and Documentation**  
- UX enhancement task: _Dependent selection for product classification_  
- Related backend change: `ProductType.subcategoryId` migration (if not already merged)