### PR TITLE
Fix/revalidate home on product edit

### DIFF
--- a/src/actions/revalidate.ts
+++ b/src/actions/revalidate.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 
 export async function revalidateProduct(productId: string): Promise<void> {
   revalidatePath(`/product/${productId}`);
+  revalidatePath("/");
 }
 
 export async function revalidateBrandPage(codeName: string): Promise<void> {

--- a/src/app/(admin)/admin/products/Products.jsx
+++ b/src/app/(admin)/admin/products/Products.jsx
@@ -102,7 +102,7 @@ const ProductsPage = () => {
         paginationMode="server"
         paginationModel={paginationModel}
         onPaginationModelChange={setPaginationModel}
-        pageSizeOptions={[10, 25, 50, 100, 500]}
+        pageSizeOptions={[10, 25, 50, 100]}
         disableRowSelectionOnClick
         sx={{
           height: 900,


### PR DESCRIPTION
# Summary

This PR includes a fix for homepage cache revalidation when editing products and reverts a previous change that introduced a 500 page size option in the admin products table.

---

# Changes

## 🐛 Fix: Homepage Revalidation

Fixed an issue where the **homepage was not being properly revalidated after editing a product**.  
Now the homepage updates correctly to reflect product changes.

---

## ↩️ Revert: Admin Products Table Page Size

Reverted the change that added a **500 items page size option** in the admin products table.

The option was removed to prevent potential performance issues when loading large datasets in the admin interface.

---

# Impact

- Ensures the homepage always reflects the latest product updates.
- Prevents potential performance degradation in the admin products table caused by very large page sizes.

---

# Testing

1. Edit a product in the admin panel.
2. Verify the homepage updates correctly after the change.
3. Open the admin products table and confirm the **500 page size option is no longer available**.