### PR TITLE
chore: harden install against supply chain attacks (Node 24 + npm 11)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,19 @@
+# Supply-chain hardening
+# Wait 1 day before installing a newly published version.
+# Mitigates Shai-Hulud-style attacks where malicious versions are pulled
+# in minutes before the registry can detect and remove them.
+# (npm value is in days; pnpm uses minutes via minimumReleaseAge)
+min-release-age=1
+
+# Block install lifecycle scripts (preinstall/install/postinstall) by default.
+# This neutralizes the primary RCE vector used by supply-chain worms.
+# If a legitimate package needs to run scripts, allowlist it explicitly.
+ignore-scripts=true
+
+# Surface vulnerabilities on install and silence funding noise.
+audit=true
+fund=false
+
+# Avoid stale lockfile churn in CI: never auto-modify the lockfile from a CI install.
+# (npm ci enforces this anyway; this is belt-and-suspenders.)
+package-lock=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,9 +1,11 @@
 # Supply-chain hardening
-# Wait 1 day before installing a newly published version.
+# Wait 3 days before installing a newly published version.
 # Mitigates Shai-Hulud-style attacks where malicious versions are pulled
-# in minutes before the registry can detect and remove them.
+# in minutes before the registry can detect and remove them. The 72h
+# window also covers slower-detection cases (some compromises took ~48h
+# to surface).
 # (npm value is in days; pnpm uses minutes via minimumReleaseAge)
-min-release-age=1
+min-release-age=3
 
 # Block install lifecycle scripts (preinstall/install/postinstall) by default.
 # This neutralizes the primary RCE vector used by supply-chain worms.

--- a/package.json
+++ b/package.json
@@ -2,10 +2,8 @@
   "name": "ferretera",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "npm@11.14.1",
   "engines": {
-    "node": ">=20.17.0",
-    "npm": ">=11.14.1"
+    "node": "24.x"
   },
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "ferretera",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "npm@11.14.1",
+  "engines": {
+    "node": ">=20.17.0",
+    "npm": ">=11.14.1"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -9,7 +14,8 @@
     "lint": "next lint",
     "test": "vitest",
     "test:run": "vitest run",
-    "prepare": "husky"
+    "prepare": "husky",
+    "setup": "npm ci && npm run prepare"
   },
   "dependencies": {
     "@emotion/cache": "^11.11.0",


### PR DESCRIPTION
# Summary

Hardens the project against the recent wave of npm supply chain attacks (Shai-Hulud / Mini Shai-Hulud) that compromised 170+ packages across the ecosystem in 2025–2026, including 42 `@tanstack/*` packages on May 11, 2026. Adopts Vercel's native Node.js 24 LTS path so the project runs on npm 11 in every environment, and enforces install-time defenses via a project-level `.npmrc`.

---

# Changes Included

## 🛡️ Supply Chain Hardening (`.npmrc`)

### 72-hour release cooldown
Adds `min-release-age=3` so npm refuses to install any package version published less than 72 hours ago. Shai-Hulud-class attacks rely on the gap between a malicious publish and registry takedown. Some compromises in the wild took up to ~48h to surface in detection feeds, so a 24h window would let those slip through. A 72h cooldown covers that worst case. It does not affect `npm ci` since that consumes the lockfile as-is — only operations that resolve new versions (local `npm install`, dependency bumps, CI lockfile regeneration).

### Install scripts disabled by default
Adds `ignore-scripts=true` to block automatic execution of `preinstall`, `install`, `postinstall`, and `prepare` scripts from dependencies. This is the primary RCE vector used by supply chain worms: they exfiltrate cloud credentials, GitHub tokens, and SSH keys by running shell on `npm install`. Local dev machines and Vercel build runners are now insulated from this vector.

### Belt-and-suspenders defaults
- `audit=true` — surface known vulnerabilities at install time
- `fund=false` — silence funding noise
- `package-lock=true` — never auto-mutate the lockfile during an install

---

## 📦 Node.js 24 LTS Adoption

### Native npm 11 on Vercel without Corepack
Bumps `engines.node` to `24.x`. Vercel supports Node 24 LTS natively (default for new projects since November 2025), and it ships with npm 11 bundled. This means `min-release-age` and the other `.npmrc` settings are honored everywhere without depending on the experimental `ENABLE_EXPERIMENTAL_COREPACK` flag.

### Dropped Corepack-based pinning
- Removed `packageManager` (Vercel ignores it without the experimental flag).
- Removed `engines.npm` constraint (npm version now tracks whatever 11.x ships with Node 24 LTS, auto-updated by Vercel for security).

---

## 🧰 Developer Ergonomics

### `setup` script for fresh clones
Since `ignore-scripts=true` blocks the automatic `prepare` lifecycle, husky git hooks no longer install themselves on `npm install`. Added a `setup` script that bundles both steps so new contributors only need to run one command after cloning.
- `"setup": "npm ci && npm run prepare"`

---

# Impact

- New malicious package versions cannot reach the project for at least 72 hours after publish, by which time the registry has typically removed them and detection feeds have flagged them.
- Dependency lifecycle scripts can no longer silently exfiltrate secrets from developer laptops or Vercel build runners.
- Project runs on Node 24 LTS + npm 11 across all environments — no drift, no experimental flags.
- One-time onboarding cost: contributors run `npm run setup` instead of `npm install` after cloning.

---

# How to Test

### Compatibility audit (already verified)
1. Verified all 707 transitive dependencies declare permissive lower-bound `engines.node` constraints — no upper bounds, no exclusions.
2. Verified locally on Node 24.15.0 with npm 11.12.1:
   - Clean install (`rm -rf node_modules && npm ci`) succeeds.
   - `next build` completes successfully.
   - All 248 vitest tests pass.

### Local install
1. Switch to Node 24:
   ```bash
   nvm install 24
   nvm use 24
   node -v   # v24.x
   npm -v    # 11.x
   ```
2. Fresh install with the new hardening:
   ```bash
   rm -rf node_modules
   npm run setup
   ```
3. Confirm hardening is active:
   ```bash
   npm config get min-release-age   # 3
   npm config get ignore-scripts    # true
   ```
4. Verify husky hooks installed by making a throwaway commit — pre-commit (lint-staged + prettier) should run.

### Vercel preview
1. In Vercel Project Settings → Build and Deployment → Node.js Version, confirm 24.x is selected (or rely on `engines.node` in `package.json` to override).
2. Push the branch and open the Preview deployment.
3. In the build logs, confirm the install step uses Node 24 and npm 11.x.
4. Smoke-test the preview URL: home page loads, product listing renders, login works.

### Tests
```bash
npm test
```